### PR TITLE
[SYNC-28] Prevent users from submitting articles with no block title

### DIFF
--- a/src/views/new/Post.vue
+++ b/src/views/new/Post.vue
@@ -393,6 +393,17 @@ export default {
 
         return
       }
+      let noTitle = false
+      this.blocks.forEach((block) => {
+        if (block.blockTitle === '') {
+          noTitle = true
+        }
+      })
+      if (noTitle) {
+        await this.$bvModal.msgBoxOk('段落標題不得為空白，請輸入標題')
+        this.isLoading = false
+        return
+      }
       this.data = {
         ...this.data,
         title: this.postTitle,


### PR DESCRIPTION
Article couldn't be submitted when there is a block without a block title.