### PR TITLE
[FE][SYNC-44] Hide article timeline and news recommendation on small screen

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -138,3 +138,9 @@ $border-color:                $primary;
 
 /* switch */
 $b-custom-control-indicator-size-lg: 1.5rem;
+
+@mixin hide-below-desktop {
+  @media only screen and (max-width: map-get($grid-breakpoints, xl)) {
+    display: none;
+  }
+}

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -426,24 +426,21 @@ p {
 }
 
 .timeline-container {
+  @include hide-below-desktop;
   width: 240px;
   right: calc(50vw + 360px + 64px);
   padding-left: 16px;
   padding-right: 0px;
-  @media only screen and (max-width: 1200px) {
-    display: none;
-  }
 }
 
 .recommendedNews-container{
+  @include hide-below-desktop;
   position: absolute;
   width: 264px;
   left: calc(50vw + 360px + 64px);
-  // top: 700+24px;
   .heading {
     margin-bottom: 16px;
   }
-
   hr.line {
     width: 129px;
     border-top: 1px solid #232323;
@@ -477,9 +474,6 @@ p {
       font-size: 20px;
       margin-top: -3px;
     }
-  }
-  @media only screen and (max-width: 1200px) {
-    display: none;
   }
 }
 

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -3,7 +3,7 @@
     <CategoryBar />
     <div v-if="isPageReady">
       <div
-        class="sync-timeline py-4 hide-below-xl"
+        class="sync-timeline py-4"
         :class=" isTimelineOutOfScreen ? 'position-fixed' : 'position-absolute'"
         :style=" isTimelineOutOfScreen ? 'top: 104px;' : 'top: ' + (barDistToTop-20) +'px;'"
       >
@@ -16,7 +16,7 @@
         </ul>
       </div>
       <div
-        class="recommended-news hide-below-xl"
+        class="recommended-news"
         :style="`top: ${firstBlockDistToTop}px;`"
       >
         <div class="d-flex align-items-center heading">
@@ -430,6 +430,9 @@ p {
   right: calc(50vw + 360px + 64px);
   padding-left: 16px;
   padding-right: 0px;
+  @media only screen and (max-width: 1200px) {
+    display: none;
+  }
 }
 
 .recommended-news{
@@ -474,6 +477,9 @@ p {
       font-size: 20px;
       margin-top: -3px;
     }
+  }
+  @media only screen and (max-width: 1200px) {
+    display: none;
   }
 }
 
@@ -534,9 +540,4 @@ html {
   scroll-behavior: smooth;
 }
 
-.hide-below-xl {
-  @media only screen and (max-width: 1200px) {
-    display: none;
-  }
-}
 </style>

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -3,7 +3,7 @@
     <CategoryBar />
     <div v-if="isPageReady">
       <div
-        class="sync-timeline py-4"
+        class="sync-timeline py-4 hide-below-xl"
         :class=" isTimelineOutOfScreen ? 'position-fixed' : 'position-absolute'"
         :style=" isTimelineOutOfScreen ? 'top: 104px;' : 'top: ' + (barDistToTop-20) +'px;'"
       >
@@ -16,7 +16,7 @@
         </ul>
       </div>
       <div
-        class="recommended-news"
+        class="recommended-news hide-below-xl"
         :style="`top: ${firstBlockDistToTop}px;`"
       >
         <div class="d-flex align-items-center heading">
@@ -532,5 +532,11 @@ li.circle{
 
 html {
   scroll-behavior: smooth;
+}
+
+.hide-below-xl {
+  @media only screen and (max-width: 1200px) {
+    display: none;
+  }
 }
 </style>

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -3,7 +3,7 @@
     <CategoryBar />
     <div v-if="isPageReady">
       <div
-        class="sync-timeline py-4"
+        class="timeline-container py-4"
         :class=" isTimelineOutOfScreen ? 'position-fixed' : 'position-absolute'"
         :style=" isTimelineOutOfScreen ? 'top: 104px;' : 'top: ' + (barDistToTop-20) +'px;'"
       >
@@ -16,7 +16,7 @@
         </ul>
       </div>
       <div
-        class="recommended-news"
+        class="recommendedNews-container"
         :style="`top: ${firstBlockDistToTop}px;`"
       >
         <div class="d-flex align-items-center heading">
@@ -425,7 +425,7 @@ p {
   }
 }
 
-.sync-timeline{
+.timeline-container {
   width: 240px;
   right: calc(50vw + 360px + 64px);
   padding-left: 16px;
@@ -435,7 +435,7 @@ p {
   }
 }
 
-.recommended-news{
+.recommendedNews-container{
   position: absolute;
   width: 264px;
   left: calc(50vw + 360px + 64px);


### PR DESCRIPTION
## Description: 
- Since the article page currently does not have RWD, the timeline and news recommendation position are not functioning properly right now.
## Changes:
- Hide both of the sidebars when screen width < 1200px