### PR TITLE
[FE] Add tooltip on icons

### DIFF
--- a/src/components/ArticleCard.vue
+++ b/src/components/ArticleCard.vue
@@ -9,7 +9,7 @@
           <div class="article-category">
             {{ getCategory(category) }}
           </div>
-          <button class="subscribe-btn" @click="handleClickBookmark()">
+          <button v-b-tooltip.hover.bottom="bookmarkTooltip" class="subscribe-btn" @click="handleClickBookmark()">
             <icon v-if="!isSubscribed" icon="save" />
             <icon v-else icon="saved" />
           </button>
@@ -84,6 +84,9 @@ export default {
   computed: {
     subscribedList() {
       return this.$store.getters['article/subscribedList']
+    },
+    bookmarkTooltip() {
+      return this.isSubscribed ? '取消收藏文章' : '收藏文章'
     }
   },
   watch: {

--- a/src/components/Editor/MenuBar.vue
+++ b/src/components/Editor/MenuBar.vue
@@ -30,18 +30,21 @@ export default {
         {
           icon: 'bold',
           title: 'Bold',
+          tooltip: '粗體',
           action: () => this.editor.chain().focus().toggleBold().run(),
           isActive: () => this.editor.isActive('bold')
         },
         {
           icon: 'underline',
           title: 'Underline',
+          tooltip: '底線',
           action: () => this.editor.chain().focus().toggleUnderline().run(),
           isActive: () => this.editor.isActive('underline')
         },
         {
           icon: 'list',
           title: 'Bullet List',
+          tooltip: '項目符號清單',
           action: () => this.editor.chain().focus().toggleBulletList().run(),
           isActive: () => this.editor.isActive('bulletList')
         },
@@ -51,6 +54,7 @@ export default {
         {
           icon: 'quote',
           title: 'Blockquote',
+          tooltip: '引用',
           action: () => this.editor.chain().focus().toggleBlockquote().run(),
           isActive: () => this.editor.isActive('blockquote')
         },
@@ -60,6 +64,7 @@ export default {
         {
           icon: 'annotation',
           title: 'Annotation',
+          tooltip: '編輯附註',
           action: () => {
             this.$emit('showModal', 'citation-modal')
           },
@@ -68,6 +73,7 @@ export default {
         {
           icon: 'link',
           title: 'Link',
+          tooltip: '超連結',
           action: () => {
             this.$emit('showModal', 'link-modal')
           },
@@ -76,6 +82,7 @@ export default {
         {
           icon: 'image',
           title: 'Image',
+          tooltip: '圖片',
           action: () => {
             this.$emit('showModal', 'upload-image-modal')
           },

--- a/src/components/Editor/MenuItem.vue
+++ b/src/components/Editor/MenuItem.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    v-b-tooltip.hover.bottom="tooltip"
     class="menu-item"
     :class="{ 'is-active': isActive ? isActive(): null }"
     :title="title"
@@ -29,6 +30,11 @@ export default {
 
     isActive: {
       type: Function,
+      default: null
+    },
+
+    tooltip: {
+      type: String,
       default: null
     }
   },

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -64,6 +64,7 @@
                 </div>
                 <div id="icons">
                   <b-button
+                    v-b-tooltip.hover.bottom="'編輯文章'"
                     class="btn-icon mx-3"
                     @click="handleEditPostRoute(`${$route.path}/post`)"
                   >
@@ -71,6 +72,7 @@
                   </b-button>
 
                   <b-button
+                    v-b-tooltip.hover.bottom="'編輯紀錄'"
                     class="btn-icon mx-3"
                     @click="handleHistoryRoute"
                   >
@@ -78,6 +80,7 @@
                   </b-button>
 
                   <b-button
+                    v-b-tooltip.hover.bottom="bookmarkTooltip"
                     class="btn-icon ml-3"
                     :class="isSubscribed ? 'subscribed': ''"
                     @click="handleClickBookmark"
@@ -195,6 +198,9 @@ export default {
     },
     isTimelineOutOfScreen() {
       return this.windowScrollY > this.barDistToTop - 124
+    },
+    bookmarkTooltip() {
+      return this.isSubscribed ? '取消收藏文章' : '收藏文章'
     }
   },
   watch: {


### PR DESCRIPTION
## Description: 
- Add icon tooltips
## Changes:
- Add tooltips for Article page, Post page, and Article card icons
## Test Scope:
-
## Screenshots (optional)
- Article card
![image](https://user-images.githubusercontent.com/39425103/134912266-858f47ec-574e-44d5-ad2e-7d98de93f2e6.png)
- Article page
![image](https://user-images.githubusercontent.com/39425103/134912307-c5bba586-e2a3-48e9-95bb-a02a633edd66.png)
- Post page
![image](https://user-images.githubusercontent.com/39425103/134912398-b12645a2-69ab-4478-bc15-532fb6b2dd53.png)

