### PR TITLE
[SYNC-69][FE] 🐛 using <icon />; avoid svg image displaying improperly

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_BASE_URL = "https://sync.muilab.org"
+VUE_APP_BASE_URL = "http://localhost:80"
 VUE_APP_API_URL = "/api/v1"

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -29,11 +29,7 @@
           >
             <a @click="currentShowingIndex = 0">
               <span aria-hidden focusable="false" class="option-icon">
-                <img
-                  role="icon"
-                  alt="icon"
-                  src="@/assets/icons/ic-edited.svg"
-                >
+                <icon icon="edited" />
               </span>
               <span class="option-text">編輯過的文章</span>
             </a>
@@ -45,11 +41,7 @@
           >
             <a @click="currentShowingIndex = 1">
               <span aria-hidden focusable="false" class="option-icon">
-                <img
-                  role="icon"
-                  alt="icon"
-                  src="@/assets/icons/ic-history.svg"
-                >
+                <icon icon="history" />
               </span>
               <span class="option-text">瀏覽紀錄</span>
             </a>
@@ -61,11 +53,7 @@
           >
             <a @click="currentShowingIndex = 2">
               <span aria-hidden focusable="false" class="option-icon">
-                <img
-                  role="icon"
-                  alt="icon"
-                  src="@/assets/icons/ic-bookmark.svg"
-                >
+                <icon icon="bookmark" />
               </span>
               <span class="option-text">收藏的文章</span>
             </a>
@@ -77,11 +65,7 @@
           >
             <a @click="currentShowingIndex = 3">
               <span aria-hidden focusable="false" class="option-icon">
-                <img
-                  role="icon"
-                  alt="icon"
-                  src="@/assets/icons/ic-settings.svg"
-                >
+                <icon icon="settings" />
               </span>
               <span class="option-text">個人設定</span>
             </a>


### PR DESCRIPTION
## Description: 
- as the title suggest. remove all the "img" tags, using <icon /> instead.
## Changes:
- remove <img />
- using <icon />
## Build Status:
- ✅ Success
## Screenshots (optional)
![圖片](https://user-images.githubusercontent.com/32424677/135642583-4c6145fe-0b34-4f88-b6f3-be2f8ca7dcf9.png)
