### PR TITLE
[HotFix][FE] 🐛 avoid passing undefined var into SET_PROFILE mutation

### DIFF
--- a/src/store/article.js
+++ b/src/store/article.js
@@ -53,7 +53,7 @@ const actions = {
     } else if (rootGetters.isLogin) {
       try {
         const { data } = await getProfile({ token: rootGetters.token })
-        commit('SET_PROFILE', data.data.articles)
+        commit('SET_PROFILE', data.data.articles || {})
         return Promise.resolve(data.data)
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
## Description: 
- While initializing, if a user have no profile in firestore. It'll pass a undefine var into SET_PROFILE mutation.
## Changes:
- pass a empty object when profile is undefine
## Build Status:
✅ Success
## Screenshots (optional)
### Before:
![圖片](https://user-images.githubusercontent.com/32424677/135747163-66af4686-c244-443d-b511-bf4823eb852e.png)
### After:
![圖片](https://user-images.githubusercontent.com/32424677/135747137-847509b1-621a-4ced-a9e9-e7ab78e2d287.png)
