### PR TITLE
[SYNC-83] Update tooltip style and text

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -14,7 +14,7 @@ $gray-400: #ced4da !default;
 $gray-500: #adb5bd !default;
 $gray-600: #6c757d !default;
 $gray-700: #495057 !default;
-$gray-800: #343a40 !default;
+$gray-800: #838691;
 $gray-900: #212529 !default;
 $black:    #000 !default;
 $text-1: rgba(0, 0, 0, 0.85);
@@ -74,7 +74,7 @@ $colors: map-merge(
 );
 
 $primary:       $gray-900;
-$secondary:     $gray-500;
+$secondary:     $gray-800;
 $success:       $green !default;
 $info:          $cyan !default;
 $warning:       $yellow !default;

--- a/src/components/ArticleCard.vue
+++ b/src/components/ArticleCard.vue
@@ -9,7 +9,7 @@
       footer-border-variant="white"
       footer-class="p-0 article-footer"
     >
-      <button v-b-tooltip.hover.bottom="bookmarkTooltip" class="subscribe-btn" @click="handleClickBookmark()">
+      <button v-b-tooltip.hover.bottom.v-secondary="bookmarkTooltip" class="subscribe-btn" @click="handleClickBookmark()">
         <icon v-if="!isSubscribed" icon="save" />
         <icon v-else icon="saved" />
       </button>

--- a/src/components/Editor/MenuItem.vue
+++ b/src/components/Editor/MenuItem.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    v-b-tooltip.hover.bottom="tooltip"
+    v-b-tooltip.hover.bottom.v-secondary="tooltip"
     class="menu-item"
     :class="{ 'is-active': isActive ? isActive(): null }"
     :title="title"

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -63,7 +63,7 @@
                 </div>
                 <div id="icons">
                   <b-button
-                    v-b-tooltip.hover.bottom="'編輯文章'"
+                    v-b-tooltip.hover.bottom.v-secondary="'編輯內容'"
                     class="btn-icon mx-3"
                     @click="handleEditPostRoute(`${$route.path}/post`)"
                   >
@@ -71,7 +71,7 @@
                   </b-button>
 
                   <b-button
-                    v-b-tooltip.hover.bottom="'編輯紀錄'"
+                    v-b-tooltip.hover.bottom.v-secondary="'查看編輯歷史'"
                     class="btn-icon mx-3"
                     @click="handleHistoryRoute"
                   >
@@ -79,7 +79,7 @@
                   </b-button>
 
                   <b-button
-                    v-b-tooltip.hover.bottom="bookmarkTooltip"
+                    v-b-tooltip.hover.bottom.v-secondary="bookmarkTooltip"
                     class="btn-icon ml-3"
                     :class="isSubscribed ? 'subscribed': ''"
                     @click="handleClickBookmark"


### PR DESCRIPTION
## Description
Update text and style of tooltip

## Changes
- Update custom scss variant secondary to $gray-500
- Modify the tooltip style, refers to [here](https://bootstrap-vue.org/docs/directives/tooltip/#tooltips)

## Screenshots
<img width="329" alt="截圖 2021-10-05 下午2 59 14" src="https://user-images.githubusercontent.com/21107283/135975178-1e025547-3fb3-4228-92f3-b2c1d94a4eda.png">
