### PR TITLE
[SYNC-92][FE] Add '未分類' as an option in categories

### DIFF
--- a/src/store/post.js
+++ b/src/store/post.js
@@ -93,7 +93,7 @@ const mutations = {
     state.postTitle = data.title
     state.postTags = data.tags || []
     state.blocks = data.blocks || []
-    state.categorySelected = data.category || ''
+    state.categorySelected = (data.category) ? data.category : '未分類'
     state.citations = data.citations || []
   }
 }
@@ -115,7 +115,7 @@ const getters = {
       blocks: state.blocks,
       citations: state.citations,
       isAnonymous: state.isAnonymous,
-      category: state.categorySelected
+      category: state.categorySelected ? state.categorySelected : '未分類'
     }
   }
 }

--- a/src/views/new/Post.vue
+++ b/src/views/new/Post.vue
@@ -195,7 +195,7 @@ export default {
       articleId: undefined,
       currentEditingEditor: null,
       isAddingTag: false,
-      categoryList: ['政經', '國際', '社會', '科技', '環境', '生活', '運動'],
+      categoryList: ['政經', '國際', '社會', '科技', '環境', '生活', '運動', '未分類'],
       items: [
         {
           text: '首頁',


### PR DESCRIPTION
## Description: 
- Add '未分類' as an option in categories
- Current articles with no category (which is an empty string), will be given `未分類` as the category from now on
## Changes:
- New articles will be initialized with `''` category
- If no category were chosen during submission, `未分類` will be assigned
## Test Scope:
-
## Screenshots (optional)
