### PR TITLE
[SYNC-93][FE][Post] Show block date and time

### DIFF
--- a/src/components/Post/BlockEditor.vue
+++ b/src/components/Post/BlockEditor.vue
@@ -23,7 +23,9 @@
           @toggle="resetDateTime"
         >
           <template #button-content>
-            <span class="d-inline-block pl-1 pr-5 btn-text">新增事件時間</span>
+            <span class="d-inline-block pl-1 pr-5 btn-text" :class="{'date-color': tempData.blockDateValue && tempData.blockTimeValue}">
+              {{ (tempData.blockDateValue && tempData.blockTimeValue) ? dropdownBtnDateTime : '新增段落事件時間' }}
+            </span>
             <span class="d-inline-block pl-2"><b-icon icon="chevron-down" class="caret" /></span>
           </template>
           <b-dropdown-form>
@@ -97,12 +99,15 @@ export default {
   computed: {
     displayDateTime() {
       return `${moment(this.tempData.blockDateValue).format('YYYY年M月DD日')} ${moment(`${this.tempData.blockDateValue} ${this.tempData.blockTimeValue}`).format('H點mm分')}`
+    },
+    dropdownBtnDateTime() {
+      return `${moment(this.tempData.blockDateValue).format('YYYY/MM/DD')} ${moment(`${this.tempData.blockDateValue} ${this.tempData.blockTimeValue}`).format('HH:mm')}`
     }
   },
   created() {
     this.tempData.blockTitle = this.block.blockTitle
-    this.tempData.blockDateValue = moment(this.block.blockDateTime).format('YYYY-MM-DD')
-    this.tempData.blockTimeValue = moment(this.block.blockDateTime).format('HH:mm:ss')
+    if (this.block.blockDateTime) { this.tempData.blockDateValue = moment(this.block.blockDateTime).format('YYYY-MM-DD') }
+    if (this.block.blockDateTime) { this.tempData.blockTimeValue = moment(this.block.blockDateTime).format('HH:mm:ss') }
     this.initialized = true
   },
   methods: {
@@ -142,7 +147,10 @@ export default {
       this.closeDropdown()
     },
     resetDateTime() {
-      const currentDatetime = this.$store.getters['post/GET_BLOCK_DATETIME'](this.block.id)
+      let currentDatetime = this.$store.getters['post/GET_BLOCK_DATETIME'](this.block.id)
+      if (currentDatetime === '') {
+        currentDatetime = new Date().toISOString()
+      }
       this.tempData.blockDateValue = moment(currentDatetime).format('YYYY-MM-DD')
       this.tempData.blockTimeValue = moment(currentDatetime).format('HH:mm:ss')
     },
@@ -190,6 +198,9 @@ export default {
     color: rgba(0,0,0, 0.8);
     border-right: 1px solid $nature-4;
     font-size: 14px;
+  }
+  .date-color {
+    color: $blue;
   }
 }
 ::v-deep .b-calendar {

--- a/src/views/new/Post.vue
+++ b/src/views/new/Post.vue
@@ -284,7 +284,7 @@ export default {
       const blockObj = {
         id: `${Utils.getRandomString()}-${(currentBlockCount + 1).toString()}`,
         blockTitle: '',
-        blockDateTime: new Date().toISOString(),
+        blockDateTime: '',
         content: null
       }
       this.$store.commit('post/ADD_BLOCK', {


### PR DESCRIPTION
## Description: 
- Modified block date-time dropdown button to show date and time
- This is the first stage of modification towards the final date-time design of the UI/UX team
   - Stage 1: Show date-time in date-time dropdown button
   - Stage 2: Option to disable date-time (able to submit article date-time as empty string)
   - Stage 3: Change date-time dropdown plugin to others (not from BS-Vue)
   - Stage 4: Final styling
## Changes:
- New blocks added now would not have any date-time value (empty string)
  - This is used to show `新增段落事件時間`
  - Date-time will be assigned the current time as soon as the dropdown is activated
## Test Scope:
- `Post.vue`
- `BlockEditor`
## Screenshots
- Block date-time is initialized with empty string -> dropdown button shows 新增段落時間
  ![image](https://user-images.githubusercontent.com/39425103/137649757-d4069be1-3442-4ae3-aea7-55805a2ce45a.png)
- Button shows chosen date-time if a value is assigned
![image](https://user-images.githubusercontent.com/39425103/137649780-6470e07f-e679-4d03-a523-dc1ac9847998.png)


