### PR TITLE
[SYNC-150][FE][Post] fix: Fix block focus behavior

### DIFF
--- a/src/components/Editor/TiptapEditor.vue
+++ b/src/components/Editor/TiptapEditor.vue
@@ -116,6 +116,7 @@ export default {
       editable: this.editable,
       content: this.content
     })
+    this.$store.commit('post/REGISTER_EDITOR', { id: this.id, editor: this.editor })
   },
 
   beforeDestroy() {

--- a/src/components/Post/NewsCard.vue
+++ b/src/components/Post/NewsCard.vue
@@ -98,14 +98,13 @@ export default {
   },
   methods: {
     importNews() {
-      const { title, url } = this // const title = this.title; const url ...
-      this.$store.dispatch('post/SUBMIT_CITATION_FORM', { title, url })
-      // this.$emit('importNews', this.content)
       const currentEditingEditor = this.$store.state.post.currentEditingEditor
       if (currentEditingEditor === null) {
-        this.$bvModal.msgBoxOk('請選擇編輯區塊，或是先新增段落後再引入')
+        this.$bvModal.msgBoxOk('請先點擊畫面左方欲引入新聞的內文輸入框，之後再從右方新聞欄中引入新聞。')
         return
       }
+      const { title, url } = this // const title = this.title; const url ...
+      this.$store.dispatch('post/SUBMIT_CITATION_FORM', { title, url })
       let str = currentEditingEditor.getHTML()
       this.content.forEach((text) => {
         str += `<p>${text}</p>`

--- a/src/store/post.js
+++ b/src/store/post.js
@@ -11,7 +11,8 @@ const getDefaultState = () => {
     citations: [],
     categorySelected: '',
     currentEditingEditor: null,
-    showAddPointsAlert: false
+    showAddPointsAlert: false,
+    currentEditors: {}
   }
 }
 
@@ -31,6 +32,7 @@ const mutations = {
   },
   DELETE_BLOCK(state, index) {
     state.blocks.splice(index, 1)
+    state.currentEditingEditor = null
   },
   UPDATE_BLOCK_CONTENT(state, { id, content }) {
     const block = state.blocks.find(b => b.id === id)
@@ -89,6 +91,9 @@ const mutations = {
   FOCUS_EDITOR(state, editor) {
     state.currentEditingEditor = editor
   },
+  REGISTER_EDITOR(state, { id, editor }) {
+    state.currentEditors[id] = editor
+  },
   INIT_POST(state, payload) {
     const data = payload.data
     state.data = data
@@ -108,6 +113,11 @@ const getters = {
       return block.blockDateTime
     }
     return ''
+  },
+  GET_EDITOR_BY_ID: (state) => (id) => {
+    let editor = null
+    if (id in state.currentEditors) editor = state.currentEditors[id]
+    return editor
   },
   GET_PUBLISH_DATA: (state) => {
     return {

--- a/src/views/new/Post.vue
+++ b/src/views/new/Post.vue
@@ -261,12 +261,14 @@ export default {
       getArticleById(articleId).then(response => {
         if (response.data.code === 200) {
           const data = response.data.data
-          console.log(data.tags)
           this.$store.commit('post/INIT_POST', { data })
           if (this.post.blocks.length === 0) {
-            this.handleAddBlock()
+            this.handleAddBlock(-1)
           }
           this.isLoading = false
+          this.$nextTick(() => {
+            this.post.currentEditingEditor = null
+          })
         } else {
           throw new Error(response.data.message)
         }
@@ -275,7 +277,7 @@ export default {
         this.isLoading = false
       })
     } else {
-      this.handleAddBlock()
+      this.handleAddBlock(-1)
     }
   },
   methods: {
@@ -290,6 +292,10 @@ export default {
       this.$store.commit('post/ADD_BLOCK', {
         index: index,
         block: blockObj
+      })
+      this.$nextTick(() => {
+        const editor = this.$store.getters['post/GET_EDITOR_BY_ID'](blockObj.id)
+        this.$store.commit('post/FOCUS_EDITOR', editor)
       })
     },
     handleDeleteBlock(index) {
@@ -350,18 +356,6 @@ export default {
     },
     focusOnTitle(blockId) {
       this.$refs[`block-${blockId}`][0].focusOnTitle()
-    },
-    adjustTagWidth(tagIndex) {
-      const el = this.$refs[`tag-${tagIndex}`][0]
-      console.log(el)
-      let len = 0
-      for (const c in this.tags[tagIndex]) {
-        if (this.tags[tagIndex][c].charCodeAt(0) < 128) len += 1
-        else len += 2
-      }
-      el.$el.style.maxWidth = `${len}ch`
-      el.$el.style.width = `${len}ch`
-      console.log(el.$el.style.maxWidth)
     }
   }
 }


### PR DESCRIPTION
## Description: 
- Block focus behaves weirdly (non-intuitive) when importing news.
## Changes:
- For new articles, the focused editor during initialization is the only block on the page
- For old articles, no block is focused
- No blocks are focused after block deletion
- When a new block is added, it is focused.
## Test Scope:
- Post.vue
## Screenshots (optional)
