### PR TITLE
Store Firebase Config in ENV Variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,5 @@
   ],
   "resolutions": {
     "prosemirror-model": "1.11.2"
-  },
-  "volta": {
-    "node": "14.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
   ],
   "resolutions": {
     "prosemirror-model": "1.11.2"
+  },
+  "volta": {
+    "node": "14.20.0"
   }
 }

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -1,8 +1,18 @@
 import firebase from 'firebase/app'
 import 'firebase/auth'
 import { removeUserInfo } from '@/utils/auth'
-import { firebaseConfig } from '../../config/firebaseConfig'
 import store from '../store/index'
+
+const firebaseConfig = {
+  apiKey: process.env.VUE_APP_FIREBASE_API_KEY,
+  authDomain: process.env.VUE_APP_FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.VUE_APP_FIREBASE_DB_URL,
+  projectId: process.env.VUE_APP_FIREBASE_PROJ_ID,
+  storageBucket: process.env.VUE_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VUE_APP_FIREBASE_APP_ID,
+  measurementId: process.env.VUE_APP_FIREBASE_MEASUREMENT_ID
+}
 
 class FirebaseAuth {
   constructor() {


### PR DESCRIPTION
## Description: 
Firebase config should not be loaded from the external javascript file.

[It is unnecessary to keep the firebase API key safe](https://firebase.google.com/docs/projects/api-keys#api-keys-for-firebase-are-different). Also, when building a docker image, it is hard to include an external file in the CI/CD pipeline.

However, as a public repo, keeping these as the project configurations is much more reasonable, making it easier to set up another firebase project.

## Changes:
- Move `firebaseConfig` into `utils/firebase.js`
- Load config from environment variables

## Build
✅