### PR TITLE
[FE][Firebase Auth] Fix Re-Login Required After Refresh The Page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,7 +8,7 @@ const isLogin = () => {
   return FirebaseAuthInstance.isLogin
 }
 
-export default new Router({
+const router = new Router({
   routes: [
     {
       path: '/',
@@ -42,15 +42,15 @@ export default new Router({
       path: '/profile',
       name: 'Profile',
       component: () => import('@/views/Profile'),
-      beforeEnter: (to, from, next) => {
-        isLogin() ? next() : next('/login')
+      meta: {
+        requiresAuth: true
       }
     },
     {
       path: '/article/:ArticleID/post',
       component: () => import('@/views/new/Post'),
-      beforeEnter: (to, from, next) => {
-        isLogin() ? next() : next('/login')
+      meta: {
+        requiresAuth: true
       }
     },
     {
@@ -61,8 +61,8 @@ export default new Router({
       path: '/post',
       name: 'Post',
       component: () => import('@/views/new/Post'),
-      beforeEnter: (to, from, next) => {
-        isLogin() ? next() : next('/login')
+      meta: {
+        requiresAuth: true
       }
     },
     {
@@ -85,3 +85,16 @@ export default new Router({
     return { x: 0, y: 0 }
   }
 })
+
+router.beforeEach(async(to, from, next) => {
+  const requiresAuth = to.matched.some(rec => rec.meta.requiresAuth)
+
+  if (requiresAuth && !isLogin()) {
+    next('/login')
+    return
+  }
+
+  next()
+})
+
+export default router

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -83,9 +83,7 @@ const router = new Router({
 })
 
 router.beforeEach(async(to, from, next) => {
-  const requiresAuth = to.matched.some(rec => rec.meta.requiresAuth)
-
-  if (requiresAuth && !await FirebaseAuthInstance.getCurrentUser()) {
+  if (to.meta.requiresAuth && !await FirebaseAuthInstance.getCurrentUser()) {
     next('/login')
     return
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,10 +4,6 @@ import FirebaseAuthInstance from '@/utils/firebase.js'
 
 Vue.use(Router)
 
-const isLogin = () => {
-  return FirebaseAuthInstance.isLogin
-}
-
 const router = new Router({
   routes: [
     {
@@ -89,7 +85,7 @@ const router = new Router({
 router.beforeEach(async(to, from, next) => {
   const requiresAuth = to.matched.some(rec => rec.meta.requiresAuth)
 
-  if (requiresAuth && !isLogin()) {
+  if (requiresAuth && !await FirebaseAuthInstance.getCurrentUser()) {
     next('/login')
     return
   }

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -12,11 +12,11 @@ class FirebaseAuth {
   }
 
   get auth() {
-    return this.instance
+    return this.app.auth()
   }
 
   get token() {
-    return this.instance.currentUser.getIdToken()
+    return this.auth.currentUser.getIdToken()
   }
 
   thirdPartyLogins = [
@@ -47,17 +47,16 @@ class FirebaseAuth {
 
     await import('/config/firebaseConfig')
       .then(({ firebaseConfig }) => {
-        this.instance = firebase.initializeApp(firebaseConfig)
+        this.app = firebase.initializeApp(firebaseConfig)
       })
       .catch((err) => {
         console.error(err)
       })
 
     try {
-      this.instance = firebase.auth()
       const handler = async(user) => {
         if (user) {
-          const token = await this.instance.currentUser
+          const token = await this.auth.currentUser
             .getIdToken(/* force refresh */ true)
             .catch((error) => {
               console.error(error)

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -2,9 +2,17 @@ import firebase from 'firebase/app'
 import 'firebase/auth'
 import { removeUserInfo } from '@/utils/auth'
 import store from '../store/index'
+import { firebaseConfig } from '/config/firebaseConfig'
 
 class FirebaseAuth {
   constructor() {
+    try {
+      this.app = firebase.initializeApp(firebaseConfig)
+    } catch (error) {
+      this.app = null
+      console.error(error)
+    }
+
     this.email = ''
     this.password = ''
     this.displayName = ''
@@ -53,14 +61,6 @@ class FirebaseAuth {
 
   async setupFirebase() {
     if (process.env.NODE_ENV === 'test') return Promise.resolve()
-
-    await import('/config/firebaseConfig')
-      .then(({ firebaseConfig }) => {
-        this.app = firebase.initializeApp(firebaseConfig)
-      })
-      .catch((err) => {
-        console.error(err)
-      })
 
     try {
       const handler = async(user) => {

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -42,6 +42,15 @@ class FirebaseAuth {
     return this.thirdPartyLoginMethods.get(id)
   }
 
+  async getCurrentUser() {
+    return new Promise((res) => {
+      const unsubscribe = this.auth.onAuthStateChanged((user) => {
+        unsubscribe()
+        res(user)
+      })
+    })
+  }
+
   async setupFirebase() {
     if (process.env.NODE_ENV === 'test') return Promise.resolve()
 


### PR DESCRIPTION
## Description: 
- Vue router does navigation guard before the auth state is confirmed. Therefore, when we refresh those auth-required pages, the router will redirect the user to the login page despite the login state.
## Major Changes:
- add subscriber `getCurrentUser()` on changes of auth state. 
- Initialize the firebase app when the `FirebaseAuthInstance` is instantiated. In order to call `getCurrentUser()`
## Minor Changes:
- Use the `meta` field to guard routes (officially recommended)
## Build Status:
✅ 