### PR TITLE
[FE][SYNC-233] Share article page blocks

### DIFF
--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -265,9 +265,16 @@ export default {
     isPageReady(newValue) {
       this.$store.commit('SET_FOOTER', newValue)
       this.setOffsetTopOfSideElements()
+      // hack to scroll to block after sidebar set
+      this.$nextTick(()=> {
+        this.scrollToBlock()
+      })
     },
-    '$route.params.ArticleID': function() {
+    '$route.params.ArticleID'() {
       this.getArticleData()
+    },
+    '$route.query'() {
+      this.scrollToBlock()
     }
   },
   created() {
@@ -417,6 +424,22 @@ export default {
     },
     updateScroll() {
       this.windowScrollY = window.scrollY
+    },
+    checkBlockExists(blockId) {
+      const refName = `block-${blockId}`
+      return refName in this.$refs
+    },
+    // if query block set, scroll to respective block
+    scrollToBlock() {
+      // check if query exists
+      const query = this.$route.query
+      if ('block' in query && this.checkBlockExists(query['block'])) {
+        // scroll to block if block exists
+        const blockRef = `block-${query['block']}`
+        this.$nextTick(() => {
+          this.scrollTo(blockRef)
+        })
+      }
     }
   }
 }

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -137,7 +137,7 @@
                   <b-button
                     v-b-tooltip.hover.bottom.v-secondary="'分享段落'"
                     class="btn-share"
-                    @click="getBlockLink(block._id)"
+                    @click="triggerShareModal(block._id, block.blockTitle)"
                   >
                     <b-icon icon="share-fill" />
                   </b-button>
@@ -195,6 +195,24 @@
             class="b-toaster-bottom-center share-block-toast--toaster"
             name="share-block-toaster"
           />
+          <b-modal
+            id="share-link--modal"
+            centered
+            title="分享段落"
+            size="lg"
+            ok-title="新增"
+            cancel-title="取消"
+            content-class="custom-modal"
+            body-class="custom-modal-body"
+            header-class="custom-modal-header"
+            hide-footer
+          >
+            <div class="share-content">
+              <div>分享此段落：<b>「{{ shareTitle }}」</b></div>
+              <b-form-input id="share-link--input" v-model="shareLink" class="input-form my-3" plaintext />
+              <b-button variant="share-link" @click="getBlockLink">複製連結</b-button>
+            </div>
+          </b-modal>
         </div>
       </transition>
     </div>
@@ -247,7 +265,9 @@ export default {
       FooterOffsetTop: 0,
       firstBlockDistToTop: 0,
       isRecommendedReady: false,
-      changePageTransition: false
+      changePageTransition: false,
+      shareLink: '',
+      shareTitle: ''
     }
   },
   computed: {
@@ -464,11 +484,15 @@ export default {
         })
       }
     },
-    getBlockLink(blockId) {
-      console.log(blockId)
+    triggerShareModal(blockId, blockTitle) {
       const url = window.location.origin + '/#' + this.$route.path
       const query = `?block=${blockId}`
-      this.copyToClipBoard(url + query)
+      this.shareLink = `${url}${query}`
+      this.shareTitle = blockTitle
+      this.$bvModal.show('share-link--modal')
+    },
+    getBlockLink() {
+      this.copyToClipBoard(this.shareLink)
       this.$nextTick(() => {
         this.$bvToast.show('share-block-toast')
       })
@@ -791,6 +815,84 @@ html {
         margin: 0 auto;
       }
     }
+  }
+  .custom-modal {
+    border-radius: 4px;
+    border: none;
+    height: 280px;
+    width: 480px;
+    margin: auto;
+    &-tall {
+      height: 448px;
+    }
+  }
+  .custom-modal-body {
+    padding: 24px 20px;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+  }
+  .custom-modal-header {
+    border-bottom: 1px solid $gray-4;
+    padding: 20px;
+  }
+  .input-form {
+    margin: 1.5px;
+    margin-bottom: 1.5px;
+    font-size: 16px;
+    height: 40px;
+    border: 1px solid $gray-4 !important;
+    border-radius: 4px;
+    padding-left: 12px;
+    &:active, &:focus {
+      border: 1px solid $blue !important;
+    }
+    &::placeholder{
+      color: $text-4;
+    }
+    &.is-invalid {
+      border: 1px solid $red !important;
+    }
+    &.is-valid {
+      border: 1px solid $green !important;
+    }
+  }
+  %normal-btn {
+    font-size: 16px;
+    line-height: 24px;
+    padding: 7px 15px;
+    border: 1px solid transparent;
+  }
+  %share-link {
+    @extend %normal-btn;
+    background-color: $blue-4;
+    border-color: $blue-4;
+    color: $white;
+    &:hover {
+      background-color: $blue-3;
+      border-color: $blue-3;
+      color: $white;
+    }
+    &:active, &:focus {
+      background-color: $blue-5 !important;
+      border-color: $blue-5 !important;
+      color: $white;
+    }
+    &:disabled {
+      background-color: $blue-2;
+      border-color: $blue-2;
+      color: $white;
+    }
+  }
+  .btn-share-link {
+    @extend %share-link;
+    border-radius: 24px;
+    display: block !important;
+    margin: auto;
+  }
+  .share-content {
+    width: 100%;
+    font-size: 16px;
   }
 }
 

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -137,11 +137,11 @@
                   <b-button
                     v-b-tooltip.hover.bottom.v-secondary="'分享段落'"
                     class="btn-share"
+                    @click="getBlockLink(block._id)"
                   >
-                    <b-icon icon="share-fill"/>
+                    <b-icon icon="share-fill" />
                   </b-button>
                 </div>
-                
                 <div v-if="block.blockDateTime" class="article-info">
                   事件時間：{{
                     formatBlockDateTime(block.blockDateTime, block.timeEnable)
@@ -181,6 +181,20 @@
               </div>
             </div>
           </div>
+          <b-toast
+            id="share-block-toast"
+            toast-class="share-block-toast--toast"
+            body-class="share-block-toast--toast-body"
+            toaster="share-block-toaster"
+            no-close-button
+            auto-hide-delay="2500"
+          >
+            已將連結複製到剪貼簿
+          </b-toast>
+          <b-toaster
+            class="b-toaster-bottom-center share-block-toast--toaster"
+            name="share-block-toaster"
+          />
         </div>
       </transition>
     </div>
@@ -275,7 +289,7 @@ export default {
       this.$store.commit('SET_FOOTER', newValue)
       this.setOffsetTopOfSideElements()
       // hack to scroll to block after sidebar set
-      this.$nextTick(()=> {
+      this.$nextTick(() => {
         this.scrollToBlock()
       })
     },
@@ -449,6 +463,18 @@ export default {
           this.scrollTo(blockRef)
         })
       }
+    },
+    getBlockLink(blockId) {
+      console.log(blockId)
+      const url = window.location.origin + '/#' + this.$route.path
+      const query = `?block=${blockId}`
+      this.copyToClipBoard(url + query)
+      this.$nextTick(() => {
+        this.$bvToast.show('share-block-toast')
+      })
+    },
+    copyToClipBoard(textToCopy) {
+      navigator.clipboard.writeText(textToCopy)
     }
   }
 }
@@ -724,5 +750,46 @@ p {
 
 html {
   scroll-behavior: smooth;
+}
+</style>
+
+<style lang="scss">
+
+//toast animation
+
+@keyframes toastAnimation {
+  from {
+    transform: translateY(3.5rem);
+  }
+  to {
+    transform: translateY(-3.5rem);
+  }
+}
+.share-block-toast {
+  &--toast {
+    position: relative;
+    background-color: $blue !important;
+    border-radius: 0.5rem;
+    transform: translateY(-3.5rem);
+
+    animation-name: toastAnimation;
+    animation-duration: 0.3s;
+    animation-timing-function: ease;
+  }
+
+  &--toast-body {
+    font-size: 18px;
+    line-height: 30px;
+    color: $white;
+    padding: 0.5rem 1rem;
+  }
+
+  &--toaster {
+    div {
+      display: flex;
+      width: fit-content;
+      margin: 0 auto;
+    }
+  }
 }
 </style>

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -753,43 +753,45 @@ html {
 }
 </style>
 
-<style lang="scss">
+<style lang="scss" scoped>
 
-//toast animation
-
-@keyframes toastAnimation {
-  from {
-    transform: translateY(3.5rem);
+// share style
+:deep(*) {
+  @keyframes toastAnimation {
+    from {
+      transform: translateY(3.5rem);
+    }
+    to {
+      transform: translateY(-3.5rem);
+    }
   }
-  to {
-    transform: translateY(-3.5rem);
-  }
-}
-.share-block-toast {
-  &--toast {
-    position: relative;
-    background-color: $blue !important;
-    border-radius: 0.5rem;
-    transform: translateY(-3.5rem);
+  .share-block-toast {
+    &--toast {
+      position: relative;
+      background-color: $blue !important;
+      border-radius: 0.5rem;
+      transform: translateY(-3.5rem);
 
-    animation-name: toastAnimation;
-    animation-duration: 0.3s;
-    animation-timing-function: ease;
-  }
+      animation-name: toastAnimation;
+      animation-duration: 0.3s;
+      animation-timing-function: ease;
+    }
 
-  &--toast-body {
-    font-size: 18px;
-    line-height: 30px;
-    color: $white;
-    padding: 0.5rem 1rem;
-  }
+    &--toast-body {
+      font-size: 18px;
+      line-height: 30px;
+      color: $white;
+      padding: 0.5rem 1rem;
+    }
 
-  &--toaster {
-    div {
-      display: flex;
-      width: fit-content;
-      margin: 0 auto;
+    &--toaster {
+      div {
+        display: flex;
+        width: fit-content;
+        margin: 0 auto;
+      }
     }
   }
 }
+
 </style>

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -284,6 +284,10 @@ export default {
     }
   },
   mounted() {
+    window.addEventListener('scroll', this.updateScroll)
+  },
+  beforeDestroy() {
+    window.removeEventListener('scroll', this.updateScroll)
   },
   methods: {
     getArticleData() {
@@ -410,6 +414,9 @@ export default {
       const element = this.$refs[refName][0]
       const top = element.offsetTop
       window.scrollTo({ left: 0, top: top - (64 + 10), behavior: 'smooth' })
+    },
+    updateScroll() {
+      this.windowScrollY = window.scrollY
     }
   }
 }

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -215,8 +215,6 @@ export default {
       editedCount: 0,
       citation: {},
       lastUpdatedAt: '',
-      timeId: null,
-      time: moment(),
       isLogin: false,
       isSubscribed: false,
       isPageReady: false,
@@ -230,12 +228,6 @@ export default {
     }
   },
   computed: {
-    getYear() {
-      return this.time.getFullYear()
-    },
-    getMonth() {
-      return this.time.getMonth()
-    },
     articleId() {
       return this.$route.params.ArticleID
     },
@@ -280,10 +272,6 @@ export default {
   },
   created() {
     this.$on('reloadData', this.getArticleData)
-    this.time = moment()
-    this.timeId = setInterval(() => {
-      this.time = moment()
-    }, 1000)
 
     this.getArticleData()
     // check if user logged in
@@ -296,12 +284,6 @@ export default {
     }
   },
   mounted() {
-    window.addEventListener('scroll', this.updateScroll)
-  },
-  beforeDestroy() {
-    clearInterval(this.timeId)
-    this.time = null
-    window.removeEventListener('scroll', this.updateScroll)
   },
   methods: {
     getArticleData() {
@@ -428,9 +410,6 @@ export default {
       const element = this.$refs[refName][0]
       const top = element.offsetTop
       window.scrollTo({ left: 0, top: top - (64 + 10), behavior: 'smooth' })
-    },
-    updateScroll() {
-      this.windowScrollY = window.scrollY
     }
   }
 }

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -130,9 +130,18 @@
               :class="citations.length === 0 ? 'no-citation' : ''"
             >
               <div class="block-header">
-                <h2>
-                  {{ block.blockTitle }}
-                </h2>
+                <div class="d-flex justify-content-between">
+                  <h2>
+                    {{ block.blockTitle }}
+                  </h2>
+                  <b-button
+                    v-b-tooltip.hover.bottom.v-secondary="'分享段落'"
+                    class="btn-share"
+                  >
+                    <b-icon icon="share-fill"/>
+                  </b-button>
+                </div>
+                
                 <div v-if="block.blockDateTime" class="article-info">
                   事件時間：{{
                     formatBlockDateTime(block.blockDateTime, block.timeEnable)
@@ -464,6 +473,15 @@ p {
   border: 0px;
   background-color: #ffffff;
   padding: 0;
+}
+
+:deep(.btn-share) {
+  border: 0px;
+  background-color: #ffffff;
+  padding: 0;
+  color: black;
+  height: 32px;
+  width: 32px;
 }
 
 .category {

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -523,6 +523,7 @@ p {
   border: 0px;
   background-color: #ffffff;
   padding: 0;
+  color: #52535A;
 }
 
 :deep(.btn-share) {


### PR DESCRIPTION
## Description: 
- Add functionality to share an article block
- User can scroll to a specific block directly by using a block query `block?={target_block}`
- Requested feature by @goeetw 
## Changes:
- Added router query parameter `block` in `Article.vue`
- Add "share" button for each article block
- New "share block" modal
## Test Scope:
- http://localhost:8080/#/article/61a8b3ede87c83de83e105e2?block=61b758fe370b8db0d0b37d72


## Screenshots (optional)
<img width="757" alt="image" src="https://user-images.githubusercontent.com/39425103/201566303-6c26c146-7e18-4420-9fc8-02360bff4de6.png">

<img width="768" alt="image" src="https://user-images.githubusercontent.com/39425103/201566439-945332b5-8da3-4aa8-b33e-bfa4e8aab375.png">

