### PR TITLE
[FE][SYNC-266] Hyperlink mark should be disabled after link added

### DIFF
--- a/src/components/Editor/TiptapEditor.vue
+++ b/src/components/Editor/TiptapEditor.vue
@@ -103,6 +103,7 @@ export default {
         }),
         Typography,
         Link.configure({
+          autolink: false,
           openOnClick: false
         }),
         Image,


### PR DESCRIPTION
## Description: 

After user add the link, the editor should not extend the link text when user type on the end of the link.

## Changes:
- set `autoLink` to false on `Link` mark

## Build Status:
✅ 
