### PR TITLE
fix: prevent the timeline panel covered the blocks

### DIFF
--- a/src/views/new/Post.vue
+++ b/src/views/new/Post.vue
@@ -4,7 +4,12 @@
       style="position: relative; width: 100vw"
       :class="{ 'justify-content-center': !showNewsSource }"
     >
-      <div v-if="isTimelineShow" align-self="stretch" class="timeline-panel">
+      <div
+        v-if="isTimelineShow"
+        align-self="stretch"
+        class="timeline-panel"
+        :class="{ 'timeline-panel__join': showNewsSource }"
+      >
         <div class="timeline-header">
           <span> 段落標題 </span>
           <b-button
@@ -28,6 +33,7 @@
         </div>
       </div>
       <div
+        v-if="!(isTimelineShow && showNewsSource)"
         class="timeline-panel-btn-only"
         :class="{ 'timeline-shrink': showNewsSource }"
       >
@@ -802,6 +808,10 @@ export default {
 .timeline-panel {
   position: absolute;
   left: 0;
+
+  &__join {
+    position: static;
+  }
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description: 

The timeline panel covered the article blocks when the both panel (timeline & source) are open. This PR fix this issue.

## Changes:

- Set the position of the timeline panel to `static` when the both panel are open.
- Hide the timeline open btn when the both panel are open

## Build Status
✅ 
