### PR TITLE
fix: prevent citation items overflow

### DIFF
--- a/src/views/new/Post.vue
+++ b/src/views/new/Post.vue
@@ -131,7 +131,7 @@
                   body-class="p-3"
                 >
                   <div class="d-flex justify-content-between">
-                    <div class="d-flex flex-column">
+                    <div class="d-flex flex-column" style="min-width: 0">
                       <div class="d-flex mb-2">
                         <div
                           class="citation-list-tag"


### PR DESCRIPTION
## Description: 
When citation text or link get's too long, the content overflow out of the card. This PR fix it.

## Changes:
- Set `min-width` to `0` to prevent flexbox from growing

## Build Status:
✅

## Screenshots (optional)

### Before
<img width="806" alt="Screenshot 2023-09-25 at 8 48 51 PM" src="https://github.com/NCTU-SYNC/sync-frontend/assets/32424677/30d6bd16-f6a1-4849-8a97-4a746997261d">

### After
<img width="694" alt="Screenshot 2023-09-25 at 8 48 25 PM" src="https://github.com/NCTU-SYNC/sync-frontend/assets/32424677/69dd6005-0452-4776-bfbc-86f275faf638">
